### PR TITLE
Fix implicit declaration of 'strncasecmp'

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -16,7 +16,7 @@ endif
 
 # Find the OS
 uname_S := $(shell sh -c 'uname -s 2>/dev/null || echo not')
-INCLUDE_DIRS = -I"$(RM_INCLUDE_DIR)" -I"$(DEPS_DIR)/jsonsl"  -I"$(DEPS_DIR)/RedisModuleSDK/rmutil"
+INCLUDE_DIRS = -I"$(RM_INCLUDE_DIR)" -I"$(DEPS_DIR)/jsonsl" -I"$(DEPS_DIR)/RedisModuleSDK"
 CFLAGS = $(INCLUDE_DIRS) -Wall $(DEBUGFLAGS) -fPIC -std=gnu99  -D_GNU_SOURCE
 CC:=$(shell sh -c 'type $(CC) >/dev/null 2>/dev/null && echo $(CC) || echo gcc')
 

--- a/src/cache.h
+++ b/src/cache.h
@@ -20,7 +20,7 @@
  * LRU Entry, per path. Stored under keys
  */
 #include "rejson.h"
-#include <sds.h>
+#include "rmutil/sds.h"
 typedef struct LruPathEntry {
     // Prev/Next in the LRU itself
     struct LruPathEntry *lru_prev;

--- a/src/json_object.h
+++ b/src/json_object.h
@@ -23,7 +23,7 @@
 #include <float.h>
 #include <jsonsl.h>
 #include <math.h>
-#include <sds.h>
+#include "rmutil/sds.h"
 #include <stdlib.h>
 #include "object.h"
 #include "rmstrndup.h"

--- a/src/object.h
+++ b/src/object.h
@@ -23,7 +23,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <sys/param.h>
-#include <vector.h>
+#include "rmutil/vector.h"
 #include "redismodule.h"
 #include "rmstrndup.h"
 

--- a/src/object_type.h
+++ b/src/object_type.h
@@ -19,7 +19,7 @@
 #define __OBJECT_TYPE_H__
 
 #include <string.h>
-#include <vector.h>
+#include "rmutil/vector.h"
 #include "object.h"
 #include "redismodule.h"
 

--- a/src/rejson.h
+++ b/src/rejson.h
@@ -18,10 +18,10 @@
 #ifndef __REJSON_H__
 #define __REJSON_H__
 
-#include <logging.h>
-#include <sds.h>
 #include <string.h>
-#include <util.h>
+#include "rmutil/logging.h"
+#include "rmutil/sds.h"
+#include "rmutil/util.h"
 #include "json_object.h"
 #include "json_path.h"
 #include "object.h"

--- a/test/Makefile
+++ b/test/Makefile
@@ -16,7 +16,7 @@ endif
 
 # find the OS
 uname_S := $(shell sh -c 'uname -s 2>/dev/null || echo not')
-INCLUDE_DIRS = -I"$(RM_INCLUDE_DIR)" -I"$(DEPS_DIR)/jsonsl"  -I"$(DEPS_DIR)/RedisModuleSDK/rmutil"
+INCLUDE_DIRS = -I"$(RM_INCLUDE_DIR)" -I"$(DEPS_DIR)/jsonsl"  -I"$(DEPS_DIR)/RedisModuleSDK/"
 CFLAGS =  $(INCLUDE_DIRS) -Wall $(DEBUGFLAGS)  -std=gnu99 -D_GNU_SOURCE
 CC:=$(shell sh -c 'type $(CC) >/dev/null 2>/dev/null && echo $(CC) || echo gcc')
 

--- a/test/json_printer.c
+++ b/test/json_printer.c
@@ -1,5 +1,5 @@
 #include <stdio.h>
-#include <alloc.h>
+#include "rmutil/alloc.h"
 #include "../src/json_object.h"
 
 int main(int argc, char **argv) {

--- a/test/test_json_object.c
+++ b/test/test_json_object.c
@@ -4,7 +4,7 @@
 #include <dirent.h>
 #include "minunit.h"
 #include "../src/json_object.h"
-#include <alloc.h>
+#include "rmutil/alloc.h"
 
 #define _JSTR(e) "\"" #e "\""
 

--- a/test/test_object.c
+++ b/test/test_object.c
@@ -5,7 +5,7 @@
 #include "../src/object.h"
 #include "../src/path.h"
 #include "minunit.h"
-#include <alloc.h>
+#include "rmutil/alloc.h"
 
 MU_TEST(testNodeString) {
     // Test creation of an empty C string


### PR DESCRIPTION
strncasecmp is declared in strings.h but the strings.h file included with the project was being included instead of strings.h from glibc.